### PR TITLE
fix the iframe attributes

### DIFF
--- a/hoc/highlight/App.js
+++ b/hoc/highlight/App.js
@@ -30,7 +30,7 @@ function Article(props) {
 function Video(props) {
     return (
         <div className="item item-video">
-            <iframe src={props.url} frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+            <iframe src={props.url} allow="autoplay; encrypted-media" allowFullScreen></iframe>
             <p className="views">Просмотров: {props.views}</p>
         </div>
     )

--- a/hoc/time/App.js
+++ b/hoc/time/App.js
@@ -9,7 +9,7 @@ function DateTime(props) {
 function Video(props) {
     return (
         <div className="video">
-            <iframe src={props.url} frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+            <iframe src={props.url} allow="autoplay; encrypted-media" allowFullScreen></iframe>
             <DateTime date={props.date} />
         </div>
     )


### PR DESCRIPTION
1. В HTML5 атрибут `frameborder="0"` был заменён на CSS-правило `border: 0;`. С учетом того, что в стилях данное css-правило прописано, необходимости в атрибуте `frameborder="0"` более нет.
2. Также исправлено написание атрибута `allowFullScreen` на camelCase-нотацию.